### PR TITLE
Allow UFO files with trailing slash to be recognized.

### DIFF
--- a/normalization/ufonormalizer.py
+++ b/normalization/ufonormalizer.py
@@ -39,7 +39,7 @@ def main(args=None):
     if args.test:
         runTests()
         return
-    inputPath = args.input
+    inputPath = os.path.normpath(args.input)
     outputPath = args.output
     onlyModified = not args.all
     if inputPath is None:


### PR DESCRIPTION
Since a UFO is a package, tab completion automatically creates the trailing slash.
It would be nice if the command `ufonormalizer font.ufo/` wouldn’t be dismissed as _not a UFO_.