### PR TITLE
Keep required plist files even if empty

### DIFF
--- a/normalization/test_ufonormalizer.py
+++ b/normalization/test_ufonormalizer.py
@@ -27,7 +27,7 @@ from ufonormalizer import (
     _normalizeGlifOutlineFormat2, _normalizeGlifContourFormat2,
     _normalizeGlifPointAttributesFormat2,
     _normalizeGlifComponentAttributesFormat2, _normalizeGlifTransformation,
-    _normalizeColorString, _convertPlistElementToObject)
+    _normalizeColorString, _convertPlistElementToObject, _normalizePlistFile)
 from ufonormalizer import __version__ as ufonormalizerVersion
 
 # Python 3.4 deprecated readPlistFromBytes and writePlistToBytes
@@ -152,6 +152,15 @@ INFOPLIST_NO_GUIDELINES = '''\
         <key>guidelines</key>
         <array/>
     </dict>
+</plist>
+'''
+
+EMPTY_PLIST = '''\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
 </plist>
 '''
 
@@ -1658,6 +1667,21 @@ class SubpathTest(unittest.TestCase):
         self.createTestFile('')
         subpathRemoveFile(self.directory, self.filename)
         self.assertFalse(os.path.exists(self.filepath))
+
+    def test__normalizePlistFile_remove_empty(self):
+        emptyPlist = os.path.join(self.directory, "empty.plist")
+        with open(emptyPlist, "w") as f:
+            f.write(EMPTY_PLIST)
+        # 'removeEmpty' keyword argument is True by default
+        _normalizePlistFile({}, self.directory, "empty.plist")
+        self.assertFalse(os.path.exists(emptyPlist))
+
+    def test__normalizePlistFile_keep_empty(self):
+        emptyPlist = os.path.join(self.directory, "empty.plist")
+        with open(emptyPlist, "w") as f:
+            f.write(EMPTY_PLIST)
+        _normalizePlistFile({}, self.directory, "empty.plist", removeEmpty=False)
+        self.assertTrue(os.path.exists(emptyPlist))
 
     def test_subpathGetModTime(self):
         self.createTestFile('')

--- a/normalization/ufonormalizer.py
+++ b/normalization/ufonormalizer.py
@@ -348,7 +348,7 @@ def normalizeGlyphNames(ufoPath, layerDirectory):
     # update contents.plist
     subpathWritePlist(newGlyphMapping, ufoPath, layerDirectory, "contents.plist")
     # normalize contents.plist
-    _normalizePlistFile({}, ufoPath, layerDirectory, "contents.plist")
+    _normalizePlistFile({}, ufoPath, layerDirectory, "contents.plist", removeEmpty=False)
     return newGlyphMapping
 
 def _test_normalizeGlyphNames(oldGlyphMapping, expectedGlyphMapping):
@@ -386,8 +386,8 @@ def _normalizePlistFile(modTimes, ufoPath, *subpath, **kwargs):
             text = normalizePropertyList(data, preprocessor=preprocessor)
             subpathWriteFile(text, ufoPath, *subpath)
             modTimes[subpath[-1]] = subpathGetModTime(ufoPath, *subpath)
-        # Don't write empty plist files.
-        else:
+        elif kwargs.get("removeEmpty", True):
+            # Don't write empty plist files, unless 'removeEmpty' is False
             subpathRemoveFile(ufoPath, *subpath)
             if subpath[-1] in modTimes:
                 del modTimes[subpath[-1]]
@@ -395,7 +395,7 @@ def _normalizePlistFile(modTimes, ufoPath, *subpath, **kwargs):
 # metainfo.plist
 
 def normalizeMetaInfoPlist(ufoPath, modTimes):
-    _normalizePlistFile(modTimes, ufoPath, "metainfo.plist")
+    _normalizePlistFile(modTimes, ufoPath, "metainfo.plist", removeEmpty=False)
 
 # fontinfo.plist
 
@@ -482,7 +482,7 @@ def normalizeKerningPlist(ufoPath, modTimes):
 # layercontents.plist
 
 def normalizeLayerContentsPlist(ufoPath, modTimes):
-    _normalizePlistFile(modTimes, ufoPath, "layercontents.plist")
+    _normalizePlistFile(modTimes, ufoPath, "layercontents.plist", removeEmpty=False)
 
 # lib.plist
 


### PR DESCRIPTION
The `_normalizePlistFile` function currently deletes any plist files which happen to be empty, including files which are required by the UFO specification like `contents.plist` or `layercontents.plist`.

This adds a 'removeEmpty' keyword argument to `_normalizePlistFile` (default is `True`) and set it to `False` whenever the empty plist file should be kept nonetheless.