### PR TITLE
always use Unix LF end of lines

### DIFF
--- a/normalization/test_ufonormalizer.py
+++ b/normalization/test_ufonormalizer.py
@@ -1644,6 +1644,14 @@ class SubpathTest(unittest.TestCase):
             text = f.read()
         self.assertEqual(text, expected_text)
 
+    def test_subpathWriteFile_newline(self):
+        mixed_eol_text = 'foo\r\nbar\nbaz\rquz'
+        expected_text = 'foo\nbar\nbaz\nquz'
+        subpathWriteFile(mixed_eol_text, self.directory, self.filename)
+        with open(self.filepath, 'r', encoding='utf-8') as f:
+            text = f.read()
+        self.assertEqual(text, expected_text)
+
     def test_subpathWritePlist(self):
         expected_data = dict([('a', 'foo'), ('b', 'bar'), ('c', '™')])
         subpathWritePlist(expected_data, self.directory, self.plistname)

--- a/normalization/ufonormalizer.py
+++ b/normalization/ufonormalizer.py
@@ -1354,7 +1354,8 @@ def subpathWriteFile(text, ufoPath, *subpath):
         existing = None
 
     if text != existing:
-        with open(path, "w", encoding="utf-8") as f:
+        # always use Unix LF end of lines
+        with open(path, "w", encoding="utf-8", newline="\n") as f:
             f.write(text)
 
 def subpathWritePlist(data, ufoPath, *subpath):


### PR DESCRIPTION
Since we are writing files in "text" mode, by default Python uses the native `os.linesep`, which on Windows is CR+LF ("\r\n").

We want all line endings to be normalized as Unix line feeds. By passing a `newline="\n"` argument to `io.open`, we make sure this is the case on every platform, including Windows.

/cc @moyogo 