### PR TITLE
[ufonormalizer] print messages using 'logging'; add -v and -q options

### DIFF
--- a/normalization/test_ufonormalizer.py
+++ b/normalization/test_ufonormalizer.py
@@ -27,7 +27,8 @@ from ufonormalizer import (
     _normalizeGlifOutlineFormat2, _normalizeGlifContourFormat2,
     _normalizeGlifPointAttributesFormat2,
     _normalizeGlifComponentAttributesFormat2, _normalizeGlifTransformation,
-    _normalizeColorString, _convertPlistElementToObject, _normalizePlistFile)
+    _normalizeColorString, _convertPlistElementToObject, _normalizePlistFile,
+    main)
 from ufonormalizer import __version__ as ufonormalizerVersion
 
 # Python 3.4 deprecated readPlistFromBytes and writePlistToBytes
@@ -1326,6 +1327,22 @@ class UFONormalizerTest(unittest.TestCase):
         element = ET.fromstring("<data>YWJj</data>")
         self.assertEqual(_convertPlistElementToObject(element),
                          plistlib.Data(b'abc'))
+
+    def test_main_verbose_or_quiet(self):
+        with self.assertRaisesRegex(SystemExit, '2'):
+            main(['-v', '-q', 'test.ufo'])
+
+    def test_main_no_path(self):
+        with self.assertRaisesRegex(SystemExit, '2'):
+            main([])
+
+    def test_main_input_does_not_exist(self):
+        with self.assertRaisesRegex(SystemExit, '2'):
+            main(['foobarbazquz'])
+
+    def test_main_input_not_ufo(self):
+        with self.assertRaisesRegex(SystemExit, '2'):
+            main(['setup.py'])
 
 
 class XMLWriterTest(unittest.TestCase):

--- a/normalization/ufonormalizer.py
+++ b/normalization/ufonormalizer.py
@@ -48,7 +48,7 @@ def main(args=None):
     if args.test:
         return runTests()
     if args.verbose and args.quiet:
-        parser.error("--quiet and --verbose options are mutually exclusive", file=sys.stderr)
+        parser.error("--quiet and --verbose options are mutually exclusive")
     logLevel = "DEBUG" if args.verbose else "ERROR" if args.quiet else "INFO"
     logging.basicConfig(level=logLevel, format="%(message)s")
     if args.input is None:


### PR DESCRIPTION
Use `logging` module to print messages to console.
Add `-v` for verbose (e.g. prints name of files being normalizer), and `-q` for quiet output.
Return non-zero exit code from `runTest()` when `unittest.main()` fails.
Use `argparse.ArgumentParser.error()` to print error messages and return exit code 2.