### PR TITLE
ufonormalizer: store modTimes and imageReferences in layerInfo's "lib"...

### DIFF
--- a/normalization/ufonormalizer.py
+++ b/normalization/ufonormalizer.py
@@ -293,9 +293,9 @@ def normalizeUFO1And2GlyphsDirectory(ufoPath, modTimes):
 def normalizeGlyphsDirectory(ufoPath, layerDirectory, onlyModified=True):
     if subpathExists(ufoPath, layerDirectory, "layerinfo.plist"):
         layerInfo = subpathReadPlist(ufoPath, layerDirectory, "layerinfo.plist")
-        layerLib = layerInfo.get("lib", {})
     else:
-        layerLib = {}
+        layerInfo = {}
+    layerLib = layerInfo.get("lib", {})
     imageReferences = {}
     if onlyModified:
         stored = readImageReferences(layerLib)
@@ -319,7 +319,8 @@ def normalizeGlyphsDirectory(ufoPath, layerDirectory, onlyModified=True):
             modTimes[fileName] = subpathGetModTime(ufoPath, layerDirectory, fileName)
     storeModTimes(layerLib, modTimes)
     storeImageReferences(layerLib, imageReferences)
-    subpathWritePlist(layerLib, ufoPath, layerDirectory, "layerinfo.plist")
+    layerInfo["lib"] = layerLib
+    subpathWritePlist(layerInfo, ufoPath, layerDirectory, "layerinfo.plist")
     normalizeLayerInfoPlist(ufoPath, layerDirectory)
     referencedImages = set(imageReferences.values())
     return referencedImages


### PR DESCRIPTION
… and not in the top-level dict.

According to the [UFO3 spec](http://www.unifiedfontobject.org/versions/ufo3/glyphs.html#layerinfo), the "layerinfo.plist" data is a dictionary containing a "color" definition and a "lib" sub-dictionary.
The ufonormalizer was confusing the top-level dictionary with the inner lib dictionary, and was overwriting the former with the content of the latter!
Instead, the "modTimes" and "imageReferences" keys must be read/written from/in the inner "lib" dict of layerinfo.plist file.

Later on, we shall also write tests for this, as well as for the whole `normalizeGlyphsDirectory` function.