### PR TITLE
Fix issue with guidelines when x, y or angle are set to 0

### DIFF
--- a/normalization/test_ufonormalizer.py
+++ b/normalization/test_ufonormalizer.py
@@ -435,6 +435,12 @@ class UFONormalizerTest(unittest.TestCase):
         result = _normalizeDictGuideline(guideline)
         self.assertEqual(result, expected)
 
+    def test_normalizeFontInfoPlist_guidelines_zero_is_not_None(self):
+        guideline = dict(x=0, y=0, angle=0)
+        expected = dict(x=0, y=0, angle=0)
+        result = _normalizeDictGuideline(guideline)
+        self.assertEqual(result, expected)
+
     def _test_glifFormat(self):
         glifFormat = {}
         glifFormat[1] = GLIFFORMAT1.strip().replace("    ", "\t")

--- a/normalization/ufonormalizer.py
+++ b/normalization/ufonormalizer.py
@@ -453,26 +453,26 @@ def _normalizeDictGuideline(guideline):
     color = guideline.get("color")
     identifier = guideline.get("identifier")
     # either x or y must be defined
-    if not x and not y:
+    if x is None and y is None:
         return
     # if angle is specified, x and y must be specified
-    if (not x or not y) and angle:
+    if (x is None or y is None) and angle is not None:
         return
     # if x and y are specified, angle must be specified
-    if (x and y) and not angle:
+    if (x is not None and y is not None) and angle is None:
         return
     # value errors
-    if x:
+    if x is not None:
         try:
             x = float(x)
         except ValueError:
             return
-    if y:
+    if y is not None:
         try:
             y = float(y)
         except ValueError:
             return
-    if angle:
+    if angle is not None:
         try:
             angle = float(angle)
         except ValueError:


### PR DESCRIPTION
the `_normalizeDictGuideline` function should not check `if x` or `if y`, but rather `if x is not None`, etc. Otherwise, perfectly legal guidelines which happen to have either x, y or angle values at 0 are stripped off by the normalizer.