### PR TITLE
do use --float-precision optional argument

### DIFF
--- a/normalization/test_ufonormalizer.py
+++ b/normalization/test_ufonormalizer.py
@@ -1489,6 +1489,31 @@ class UFONormalizerTest(unittest.TestCase):
                 main(["-o", outdir, indir])
                 self.assertTrue(os.path.exists(os.path.join(outdir, "metainfo.plist")))
 
+    def test_main_float_precision_argument(self):
+        metainfo = METAINFO_PLIST % 3
+        libdata = """<?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+            <dict>
+                <key>test_float</key>
+                <real>0.3333333333333334</real>
+            </dict>
+        </plist>
+        """
+        with TemporaryDirectory(suffix=".ufo") as indir:
+            outdir = os.path.join(indir, 'output.ufo')
+
+            subpathWriteFile(metainfo, indir, "metainfo.plist")
+            subpathWriteFile(libdata, indir, "lib.plist")
+
+            main(["-o", outdir, "--float-precision=0", indir])
+            data = subpathReadPlist(outdir, "lib.plist")
+            self.assertEqual(data["test_float"], 0)
+
+            main(["-o", outdir, "--float-precision=10", indir])
+            data = subpathReadPlist(outdir, "lib.plist")
+            self.assertEqual(data["test_float"], 0.3333333333)
+
 
 class XMLWriterTest(unittest.TestCase):
     def __init__(self, methodName):

--- a/normalization/test_ufonormalizer.py
+++ b/normalization/test_ufonormalizer.py
@@ -1515,7 +1515,12 @@ class UFONormalizerTest(unittest.TestCase):
             data = subpathReadPlist(outdir, "lib.plist")
             self.assertEqual(data["test_float"], 0)
 
-            main(["-o", outdir, "--float-precision=16", indir])
+            main(["-o", outdir, "--float-precision=6", indir])
+            data = subpathReadPlist(outdir, "lib.plist")
+            self.assertEqual(data["test_float"], 0.333333)
+
+            # -1 means no rounding, use repr()
+            main(["-o", outdir, "--float-precision=-1", indir])
             data = subpathReadPlist(outdir, "lib.plist")
             self.assertEqual(data["test_float"], 0.3333333333333334)
 

--- a/normalization/test_ufonormalizer.py
+++ b/normalization/test_ufonormalizer.py
@@ -1506,13 +1506,18 @@ class UFONormalizerTest(unittest.TestCase):
             subpathWriteFile(metainfo, indir, "metainfo.plist")
             subpathWriteFile(libdata, indir, "lib.plist")
 
+            # without --float-precision, it uses 10 decimal digits by default
+            main(["-o", outdir, indir])
+            data = subpathReadPlist(outdir, "lib.plist")
+            self.assertEqual(data["test_float"], 0.3333333333)
+
             main(["-o", outdir, "--float-precision=0", indir])
             data = subpathReadPlist(outdir, "lib.plist")
             self.assertEqual(data["test_float"], 0)
 
-            main(["-o", outdir, "--float-precision=10", indir])
+            main(["-o", outdir, "--float-precision=16", indir])
             data = subpathReadPlist(outdir, "lib.plist")
-            self.assertEqual(data["test_float"], 0.3333333333)
+            self.assertEqual(data["test_float"], 0.3333333333333334)
 
 
 class XMLWriterTest(unittest.TestCase):

--- a/normalization/ufonormalizer.py
+++ b/normalization/ufonormalizer.py
@@ -78,7 +78,8 @@ def main(args=None):
         message += " Processing all files."
     log.info(message, os.path.basename(inputPath))
     start = time.time()
-    normalizeUFO(inputPath, outputPath=outputPath, onlyModified=onlyModified)
+    normalizeUFO(inputPath, outputPath=outputPath, onlyModified=onlyModified,
+                 floatPrecision=floatPrecision)
     runtime = time.time() - start
     log.info("Normalization complete (%.4f seconds).", runtime)
 


### PR DESCRIPTION
I just noticed we were not using the value returned from `--float-precision` command line argument.
My bad, sorry 😞 