### PR TITLE
Fix crash in normalization of data in lib

### DIFF
--- a/src/ufonormalizer.py
+++ b/src/ufonormalizer.py
@@ -116,7 +116,7 @@ except NameError:
 if hasattr(plistlib, "loads"):
 
     def _loads(data):
-        return plistlib.loads(data)
+        return plistlib.loads(data, use_builtin_types=False)
 
     def _dumps(plist):
         return plistlib.dumps(plist)


### PR DESCRIPTION
~~First I'm pushing a test to check that it's not my machine that behaves strangely~~

There was indeed a problem: https://travis-ci.org/unified-font-object/ufoNormalizer/builds/372927710