### PR TITLE
Preserve empty strings

### DIFF
--- a/src/ufonormalizer.py
+++ b/src/ufonormalizer.py
@@ -1090,6 +1090,8 @@ def _convertPlistElementToObject(element):
             else:
                 obj[key] = _convertPlistElementToObject(subElement)
     elif tag == "string":
+        if not element.text:
+            return ""
         return xmlEscapeText(element.text)
     elif tag == "data":
         return plistlib.Data.fromBase64(element.text)

--- a/tests/data/glif/format1.glif
+++ b/tests/data/glif/format1.glif
@@ -24,6 +24,8 @@
 	</outline>
 	<lib>
 		<dict>
+			<key>abc</key>
+			<string></string>
 			<key>com.letterror.somestuff</key>
 			<string>arbitrary custom data!</string>
 		</dict>

--- a/tests/data/glif/format2.glif
+++ b/tests/data/glif/format2.glif
@@ -27,6 +27,8 @@
 	<guideline name="overshoot" y="-12"/>
 	<lib>
 		<dict>
+			<key>abc</key>
+			<string></string>
 			<key>com.letterror.somestuff</key>
 			<string>arbitrary custom data!</string>
 			<key>public.markColor</key>

--- a/tests/test_ufonormalizer.py
+++ b/tests/test_ufonormalizer.py
@@ -753,6 +753,8 @@ class UFONormalizerTest(unittest.TestCase):
             <dict>
                 <key>foo</key>
                 <string>bar</string>
+                <key>abc</key>
+                <string></string>
             </dict>
         </lib>
         '''.strip()
@@ -761,8 +763,10 @@ class UFONormalizerTest(unittest.TestCase):
         _normalizeGlifLib(element, writer)
         self.assertEqual(
             writer.getText(),
-            '<lib>\n\t<dict>\n\t\t<key>foo</key>\n\t\t<string>bar</string>'
-            '\n\t</dict>\n</lib>')
+            '<lib>\n\t<dict>\n'
+            '\t\t<key>abc</key>\n\t\t<string></string>\n'
+            '\t\t<key>foo</key>\n\t\t<string>bar</string>\n'
+            '\t</dict>\n</lib>')
 
     def test_normalizeGLIF_lib_undefined(self):
         element = ET.fromstring("<lib></lib>")

--- a/tests/test_ufonormalizer.py
+++ b/tests/test_ufonormalizer.py
@@ -105,6 +105,8 @@ GLIFFORMAT1 = '''\
     </outline>
     <lib>
         <dict>
+            <key>abc</key>
+            <string></string>
             <key>com.letterror.somestuff</key>
             <string>arbitrary custom data!</string>
         </dict>
@@ -142,6 +144,8 @@ GLIFFORMAT2 = '''\
     <guideline name="overshoot" y="-12"/>
     <lib>
         <dict>
+            <key>abc</key>
+            <string></string>
             <key>com.letterror.somestuff</key>
             <string>arbitrary custom data!</string>
             <key>public.markColor</key>


### PR DESCRIPTION
Currently,
```
	<lib>
		<dict>
			<key>abc</key>
			<string></string>
		</dict>
	</lib>
```
is turned into
```
	<lib>
		<dict>
			<key>abc</key>
		</dict>
	</lib>
```

Add a test first.