### PR TITLE
Be more permissive for horizontal & vertical guidelines

### DIFF
--- a/src/ufonormalizer.py
+++ b/src/ufonormalizer.py
@@ -452,6 +452,7 @@ def _normalizeDictGuideline(guideline):
     """
     - Don't write if angle is defined but either x or y are not defined.
     - Don't write if both x and y are defined but angle is not defined.
+      However <x=300 y=0> or <x=0 y=300> are allowed, and the 0 becomes None.
     """
     x = guideline.get("x")
     y = guideline.get("y")
@@ -459,15 +460,6 @@ def _normalizeDictGuideline(guideline):
     name = guideline.get("name")
     color = guideline.get("color")
     identifier = guideline.get("identifier")
-    # either x or y must be defined
-    if x is None and y is None:
-        return
-    # if angle is specified, x and y must be specified
-    if (x is None or y is None) and angle is not None:
-        return
-    # if x and y are specified, angle must be specified
-    if (x is not None and y is not None) and angle is None:
-        return
     # value errors
     if x is not None:
         try:
@@ -484,6 +476,21 @@ def _normalizeDictGuideline(guideline):
             angle = float(angle)
         except ValueError:
             return
+    # <x=300 y=0> or <x=0 y=300> are allowed, and the 0 becomes None.
+    if angle is None:
+        if x == 0:
+            x = None
+        if y == 0:
+            y = None
+    # either x or y must be defined
+    if x is None and y is None:
+        return
+    # if angle is specified, x and y must be specified
+    if (x is None or y is None) and angle is not None:
+        return
+    # if x and y are specified, angle must be specified
+    if (x is not None and y is not None) and angle is None:
+        return
     normalized = {}
     if x is not None:
         normalized["x"] = x

--- a/src/ufonormalizer.py
+++ b/src/ufonormalizer.py
@@ -476,7 +476,8 @@ def _normalizeDictGuideline(guideline):
             angle = float(angle)
         except ValueError:
             return
-    # <x=300 y=0> or <x=0 y=300> are allowed, and the 0 becomes None.
+    # The spec was ambiguous about y=0 or x=0, so don't raise an error here,
+    # instead, <x=300 y=0> or <x=0 y=300> are allowed, and the 0 becomes None.
     if angle is None:
         if x == 0:
             x = None

--- a/tests/test_ufonormalizer.py
+++ b/tests/test_ufonormalizer.py
@@ -747,6 +747,20 @@ class UFONormalizerTest(unittest.TestCase):
         _normalizeGlifGuideline(element, writer)
         self.assertEqual(writer.getText(), '')
 
+    def test_normalizeFontInfoPlist_guidelines_vertical_y_is_zero(self):
+        # Actually a vertical guide
+        element = ET.fromstring("<guideline x='100' y='0'/>")
+        writer = XMLWriter(declaration=None)
+        _normalizeGlifGuideline(element, writer)
+        self.assertEqual(writer.getText(), '<guideline x="100"/>')
+
+    def test_normalizeFontInfoPlist_guidelines_horizontal_x_is_zero(self):
+        # Actually an horizontal guide
+        element = ET.fromstring("<guideline x='0.0' y='100'/>")
+        writer = XMLWriter(declaration=None)
+        _normalizeGlifGuideline(element, writer)
+        self.assertEqual(writer.getText(), '<guideline y="100"/>')
+
     def test_normalizeGLIF_lib_defined(self):
         e = '''
         <lib>


### PR DESCRIPTION
This is both a contribution and a question: we recently came upon horizontal and vertical guidelines being stored in UFO by some version of Robofont 3 (not the latest build) as:

```xml
  <guideline x="120" y="0"/>
  <guideline x="860" y="0"/>
  <guideline x="0" y="2920"/>
```

Currently, `ufonormalizer` considers those invalid and removes them, but they make sense as vertical or horizontal and the [spec](http://unifiedfontobject.org/versions/ufo3/fontinfo.plist/#guidelines) doesn't explicitly forbid them (that's how I read it).

This patch accepts those guidelines and normalizes them by removing the "0" coordinate. But is it a good idea? Or is it more a matter of clarifying slightly the spec, and a fluke in Robofont? (I couldn't reproduce the weird guidelines with the latest version).

@moyogo 
