### PR TITLE
GLIF plist loading: Do not escape strings and keys when loading

### DIFF
--- a/src/ufonormalizer.py
+++ b/src/ufonormalizer.py
@@ -1086,13 +1086,13 @@ def _convertPlistElementToObject(element):
         key = None
         for subElement in element:
             if subElement.tag == "key":
-                key = xmlEscapeText(subElement.text)
+                key = subElement.text
             else:
                 obj[key] = _convertPlistElementToObject(subElement)
     elif tag == "string":
         if not element.text:
             return ""
-        return xmlEscapeText(element.text)
+        return element.text
     elif tag == "data":
         if not element.text:
             return plistlib.Data.fromBase64("")

--- a/tests/test_ufonormalizer.py
+++ b/tests/test_ufonormalizer.py
@@ -1384,11 +1384,11 @@ class UFONormalizerTest(unittest.TestCase):
         element = ET.fromstring("<dict><key>foo</key><string>bar</string></dict>")
         self.assertEqual(_convertPlistElementToObject(element), {'foo': 'bar'})
         element = ET.fromstring("<dict><key>A&amp;B</key><string>B&amp;A</string></dict>")
-        self.assertEqual(_convertPlistElementToObject(element), {'A&amp;B': 'B&amp;A'})
+        self.assertEqual(_convertPlistElementToObject(element), {'A&B': 'B&A'})
         element = ET.fromstring("<string>foo</string>")
         self.assertEqual(_convertPlistElementToObject(element), 'foo')
         element = ET.fromstring("<string>&amp;</string>")
-        self.assertEqual(_convertPlistElementToObject(element), '&amp;')
+        self.assertEqual(_convertPlistElementToObject(element), '&')
         element = ET.fromstring("<date>2015-07-05T22:16:18Z</date>")
         self.assertEqual(_convertPlistElementToObject(element),
                          datetime.datetime(2015, 7, 5, 22, 16, 18))


### PR DESCRIPTION
etree unescapes for us. This avoids double-escaping  `&`, `<` and `>`. The XML writer escapes them again.