### PR TITLE
Add basic readme to explain installation and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,26 @@
 
 Provides a standard formatting so that there are meaningful diffs in version control rather than formatting noise.
 
-Examples of formatting changes include:
+Examples of formatting applied by ufoNormalizer include:
 - Changing floating-point numbers to integers where it doesn't alter the value (e.g. `x="95.0"` becomes `x="95"` )
 - Rounding floating-point numbers to 10 digits
 - Formatting XML with tabs rather than spaces
 
-## Installation
+## Usage in RoboFont
+
+RoboFont comes with ufoNormalizer pre-installed, and you can set a prefence to normalize UFOs on save.
+
+Simply open the Scripting Window and run the following code:
+
+```
+from mojo.UI import setDefault
+
+setDefault("shouldNormalizeOnSave", True)
+```
+
+## Advanced usage
+
+### Installation
 
 Install these tools using the [pip](https://pip.pypa.io/en/stable/installing/) package [hosted on PyPI](https://pypi.org/project/ufonormalizer/):
 
@@ -21,7 +35,7 @@ Install these tools using the [pip](https://pip.pypa.io/en/stable/installing/) p
 pip install --upgrade ufonormalizer
 ```
 
-## Basic usage
+### Basic usage
 
 Use on the command line:
 
@@ -37,22 +51,18 @@ ufonormalizer --help
 
 Note: if you are working on a UFO within RoboFont and run ufoNormalizer on that UFO, RoboFont will notify you that the UFO has been updated externally. Simply accept this by selecting "Update."
 
-## Automatic usage
+### Automatic usage
 
-ufoNormalizer is much more useful if used in an automated manner, so you don't have to think about it. 
+Beyond basic command-line usage, ufoNormalizer can be used in an automated manner. 
 
-Two methods of this are 
-1. Using withing a Git hook
-2. Enabling RoboFont's preference for normalizing on save
-
-### Using in a Git hook
+Of course, you can automate it to run from a shell script or a Python script. One useful possibility is using it within a Git hook.
 
 > Git hooks are scripts that Git executes before or after events such as: commit, push, and receive. Git hooks are a built-in feature - no need to download anything. Git hooks are run locally.
 – from [Git Hooks](https://githooks.com/)
 
 It's easy to set up a git hook that will normalize ufos in a project immediately before each commit, ensuring that you only ever commit clean UFO data.
 
-In your project, navigate to `/.git/hooks` and replace `pre-commit.sample` with the following code, then remove the file extension:
+In a Git project, navigate to `/.git/hooks` and replace `pre-commit.sample` with the following code, then remove the file extension:
 
 ```bash
 #!/bin/sh
@@ -73,17 +83,4 @@ done
 
 Now, each time you commit, all `.ufo`s in your Git project will be normalized before being recorded by Git.
 
-Because this hook is within the immediate project, this configuration will only apply to the immediate project. You will need to update each project to use this Git hook to normalize UFOs elsewhere. If you wish for this hook to be added to all future git projects, you can [configure a global git template](https://coderwall.com/p/jp7d5q/create-a-global-git-commit-hook). However, this approach probably doesn't make sense if you work on projects that don't involve UFO files. 
-
-### Enabling RoboFont's preference for normalizing on save
-
-If you are working within RoboFont, you can set it to normalize UFOs on save.
-
-Simply open the Scripting Window and run the following code:
-
-```
-from mojo.UI import setDefault
-
-setDefault("shouldNormalizeOnSave", True)
-```
-
+Because this hook is setup within the immediate project, this configuration will only apply to the immediate project. You will need to update each project to use this Git hook if you wish to normalize UFOs elsewhere. If you want this hook to be added to all future git projects, you can [configure a global git template](https://coderwall.com/p/jp7d5q/create-a-global-git-commit-hook). However, this approach probably doesn't make sense if you also work on projects that don't involve UFO files. 


### PR DESCRIPTION
Thanks to @benkiel and @frankrolf for [introducing and explaining this tool on a Twitter thread](https://twitter.com/kioskfonts/status/1088358248372146177). 

I felt a little uncertain coming into this repo, so I put together a very basic guide, partially based on the README of https://github.com/googlefonts/gftools. 

The basic description of the tool is quoted from Ben. Examples of formatting are observations from running the tool on a (very new) UFO of my own. 

Thoughts:
- If it's useful to add more examples of what formatting is applied, I'm happy to do so (I'm also happy for this to be expanded upon by others, of course).
- If it would be beneficial to link to a guide on virtual environments, I can also add that.

Question:
- Is there a good way to integrate this into a workflow? For instance, is there some way to configure git to run formatting when files are staged, or a good way to watch UFO files for changes, to then format? If so, that might be really useful to add to this README.

Thanks for a useful tool! Hope my small addition is helpful.