### PR TITLE
Attempting to prevent multiple indentions of notes

### DIFF
--- a/src/ufonormalizer.py
+++ b/src/ufonormalizer.py
@@ -5,7 +5,6 @@ from __future__ import print_function, unicode_literals
 import time
 import os
 import shutil
-import re
 from xml.etree import cElementTree as ET
 import plistlib
 import textwrap
@@ -159,10 +158,10 @@ else:
 class UFONormalizerError(Exception):
     pass
 
+NEWLINE_RE = re.compile(r"[\n|\r|\r\n]\t*")
 
 DEFAULT_FLOAT_PRECISION = 10
 FLOAT_FORMAT = "%%.%df" % DEFAULT_FLOAT_PRECISION
-
 
 def normalizeUFO(ufoPath, outputPath=None, onlyModified=True,
                  floatPrecision=DEFAULT_FLOAT_PRECISION, writeModTimes=True):
@@ -1179,10 +1178,10 @@ class XMLWriter(object):
         self.raw(line)
 
     def text(self, text):
-        text = text.strip()
+        text = textwrap.dedent(text)
         text = xmlEscapeText(text)
         paragraphs = []
-        for paragraph in re.split(r"\n\t*", text):
+        for paragraph in text.splitlines():
             if not paragraph:
                 paragraphs.append("")
             else:

--- a/src/ufonormalizer.py
+++ b/src/ufonormalizer.py
@@ -5,6 +5,7 @@ from __future__ import print_function, unicode_literals
 import time
 import os
 import shutil
+import re
 from xml.etree import cElementTree as ET
 import plistlib
 import textwrap
@@ -1185,6 +1186,7 @@ class XMLWriter(object):
             if not paragraph:
                 paragraphs.append("")
             else:
+                paragraph = re.sub(r"^\t", "", paragraph)
                 paragraph = textwrap.wrap(
                     paragraph.rstrip(),
                     width=xmlTextMaxLineLength,

--- a/src/ufonormalizer.py
+++ b/src/ufonormalizer.py
@@ -1179,13 +1179,10 @@ class XMLWriter(object):
         self.raw(line)
 
     def text(self, text):
-        print("1 >>>", text)
         text = text.strip("\n")
         text = dedent_tabs(text)
         text = text.strip()
-        print("2 >>>", text)
         text = xmlEscapeText(text)
-        print("3 >>>", text)
         paragraphs = []
         # for paragraph in NEWLINE_RE.split(text):
         for paragraph in text.splitlines():
@@ -1203,7 +1200,6 @@ class XMLWriter(object):
                 )
                 paragraphs.extend(paragraph)
         for line in paragraphs:
-            print("4 >>>", line)
             self.raw(line)
 
     def simpleElement(self, tag, attrs={}, value=None):

--- a/src/ufonormalizer.py
+++ b/src/ufonormalizer.py
@@ -159,8 +159,6 @@ else:
 class UFONormalizerError(Exception):
     pass
 
-NEWLINE_RE = re.compile(r"[\n|\r|\r\n]\t*")
-
 DEFAULT_FLOAT_PRECISION = 10
 FLOAT_FORMAT = "%%.%df" % DEFAULT_FLOAT_PRECISION
 
@@ -1184,7 +1182,6 @@ class XMLWriter(object):
         text = text.strip()
         text = xmlEscapeText(text)
         paragraphs = []
-        # for paragraph in NEWLINE_RE.split(text):
         for paragraph in text.splitlines():
             if not paragraph:
                 paragraphs.append("")
@@ -1367,8 +1364,8 @@ def xmlConvertInt(value):
 # Text Operations
 # ---------------
 
-_whitespace_only_re = re.compile('^[\s\t]+$', re.MULTILINE)
-_leading_whitespace_re = re.compile('(^(?:\s{4}|\t)*)(?:[^\t\n])', re.MULTILINE)
+WHITESPACE_ONLY_RE = re.compile('^[\s\t]+$', re.MULTILINE)
+LEADING_WHITESPACE_RE = re.compile('(^(?:\s{4}|\t)*)(?:[^\t\n])', re.MULTILINE)
 
 def dedent_tabs(text):
     """
@@ -1384,8 +1381,8 @@ def dedent_tabs(text):
     # Look for the longest leading string of spaces and tabs common to
     # all lines.
     margin = None
-    text = _whitespace_only_re.sub('', text)
-    indents = _leading_whitespace_re.findall(text)
+    text = WHITESPACE_ONLY_RE.sub('', text)
+    indents = LEADING_WHITESPACE_RE.findall(text)
     for indent in indents:
         if margin is None:
             margin = indent

--- a/src/ufonormalizer.py
+++ b/src/ufonormalizer.py
@@ -1182,11 +1182,10 @@ class XMLWriter(object):
         text = text.strip()
         text = xmlEscapeText(text)
         paragraphs = []
-        for paragraph in text.splitlines():
+        for paragraph in re.split(r"\n\t*", text):
             if not paragraph:
                 paragraphs.append("")
             else:
-                paragraph = re.sub(r"^\t", "", paragraph)
                 paragraph = textwrap.wrap(
                     paragraph.rstrip(),
                     width=xmlTextMaxLineLength,

--- a/src/ufonormalizer.py
+++ b/src/ufonormalizer.py
@@ -4,6 +4,7 @@ from __future__ import print_function, unicode_literals
 
 import time
 import os
+import re
 import shutil
 from xml.etree import cElementTree as ET
 import plistlib
@@ -1178,9 +1179,15 @@ class XMLWriter(object):
         self.raw(line)
 
     def text(self, text):
-        text = textwrap.dedent(text)
+        print("1 >>>", text)
+        text = text.strip("\n")
+        text = dedent_tabs(text)
+        text = text.strip()
+        print("2 >>>", text)
         text = xmlEscapeText(text)
+        print("3 >>>", text)
         paragraphs = []
+        # for paragraph in NEWLINE_RE.split(text):
         for paragraph in text.splitlines():
             if not paragraph:
                 paragraphs.append("")
@@ -1196,6 +1203,7 @@ class XMLWriter(object):
                 )
                 paragraphs.extend(paragraph)
         for line in paragraphs:
+            print("4 >>>", line)
             self.raw(line)
 
     def simpleElement(self, tag, attrs={}, value=None):
@@ -1357,6 +1365,64 @@ def xmlConvertFloat(value):
 
 def xmlConvertInt(value):
     return str(value)
+
+
+# ---------------
+# Text Operations
+# ---------------
+
+_whitespace_only_re = re.compile('^[\s\t]+$', re.MULTILINE)
+_leading_whitespace_re = re.compile('(^(?:\s{4}|\t)*)(?:[^\t\n])', re.MULTILINE)
+
+def dedent_tabs(text):
+    """
+    Based on `textwrap.dedent`, but modified to only work on tabs and 4-space indents
+
+    Remove any common leading tabs from every line in `text`.
+    This can be used to make triple-quoted strings line up with the left
+    edge of the display, while still presenting them in the source code
+    in indented form.
+
+    Entirely blank lines are normalized to a newline character.
+    """
+    # Look for the longest leading string of spaces and tabs common to
+    # all lines.
+    margin = None
+    text = _whitespace_only_re.sub('', text)
+    indents = _leading_whitespace_re.findall(text)
+    for indent in indents:
+        if margin is None:
+            margin = indent
+
+        # Current line more deeply indented than previous winner:
+        # no change (previous winner is still on top).
+        elif indent.startswith(margin):
+            pass
+
+        # Current line consistent with and no deeper than previous winner:
+        # it's the new winner.
+        elif margin.startswith(indent):
+            margin = indent
+
+        # Find the largest common whitespace between current line and previous
+        # winner.
+        else:
+            for i, (x, y) in enumerate(zip(margin, indent)):
+                if x != y:
+                    margin = margin[:i]
+                    break
+
+    # sanity check (testing/debugging only)
+    if 0 and margin:
+        for line in text.split("\n"):
+            assert not line or line.startswith(margin), \
+                   "line = %r, margin = %r" % (line, margin)
+
+    if margin:
+        text = re.sub(r'(?m)^' + margin, '', text)
+    return text
+
+
 
 # ---------------
 # Path Operations

--- a/tests/test_ufonormalizer.py
+++ b/tests/test_ufonormalizer.py
@@ -836,6 +836,15 @@ class UFONormalizerTest(unittest.TestCase):
             writer.getText(),
             "<note>\n\tLine1\n\t\n\t    Line3\n</note>")
 
+        # Normalizer should not indent Line2 and Line3 more than already indented
+        element = ET.fromstring(
+            "<note>\n\tLine1\n\tLine2\n\tLine3\n</note>")
+        writer = XMLWriter(declaration=None)
+        _normalizeGlifNote(element, writer)
+        self.assertEqual(
+            writer.getText(),
+            "<note>\n\tLine1\n\tLine2\n\tLine3\n</note>")
+
     def test_normalizeGLIF_note_undefined(self):
         element = ET.fromstring("<note></note>")
         writer = XMLWriter(declaration=None)

--- a/tests/test_ufonormalizer.py
+++ b/tests/test_ufonormalizer.py
@@ -845,6 +845,44 @@ class UFONormalizerTest(unittest.TestCase):
             writer.getText(),
             "<note>\n\tLine1\n\tLine2\n\tLine3\n</note>")
 
+        # Normalizer should keep the extra tab in line 2
+        element = ET.fromstring(
+            "<note>\n\tLine1\n\t\tLine2\n\tLine3\n</note>")
+        writer = XMLWriter(declaration=None)
+        _normalizeGlifNote(element, writer)
+        self.assertEqual(
+            writer.getText(),
+            "<note>\n\tLine1\n\t\tLine2\n\tLine3\n</note>")
+
+        # Normalizer should keep the extra spaces on line 2
+        element = ET.fromstring(
+            "<note>\n\tLine1\n\t    Line2\n\tLine3\n</note>")
+        writer = XMLWriter(declaration=None)
+        _normalizeGlifNote(element, writer)
+        self.assertEqual(
+            writer.getText(),
+            "<note>\n\tLine1\n\t    Line2\n\tLine3\n</note>")
+
+        # Normalizer should remove the extra tab all lines have in common,
+        # but leave the additional tab on line 2
+        element = ET.fromstring(
+            "<note>\n\t\tLine1\n\t\t\tLine2\n\t\tLine3\n</note>")
+        writer = XMLWriter(declaration=None)
+        _normalizeGlifNote(element, writer)
+        self.assertEqual(
+            writer.getText(),
+            "<note>\n\tLine1\n\t\tLine2\n\tLine3\n</note>")
+
+        # Normalizer should remove the extra 4-space all lines have in common,
+        # but leave the additional 4-space on line 2
+        element = ET.fromstring(
+            "<note>\n        Line1\n            Line2\n        Line3\n</note>")
+        writer = XMLWriter(declaration=None)
+        _normalizeGlifNote(element, writer)
+        self.assertEqual(
+            writer.getText(),
+            "<note>\n\tLine1\n\t    Line2\n\tLine3\n</note>")
+
     def test_normalizeGLIF_note_undefined(self):
         element = ET.fromstring("<note></note>")
         writer = XMLWriter(declaration=None)


### PR DESCRIPTION
This should fix #71 if approved.

It uses regex to remove the first tab in each line of a multi-paragraph text block.

Test added to make sure 
```xml
<note>
	Line1
	Line2
	Line3
</note>
```
does not change when it goes through `_normalizeGlifNote` into something like

```xml
<note>
	Line1
		Line2
		Line3
</note>
```
etc.