### PR TITLE
Make sure images come through

### DIFF
--- a/src/ufonormalizer/__init__.py
+++ b/src/ufonormalizer/__init__.py
@@ -646,7 +646,7 @@ def normalizeGLIFString(text, glifPath=None, imageFileRef=None):
     if advance is not None:
         _normalizeGlifAdvance(advance, writer)
     if glifVersion >= 2 and image is not None:
-        imageFileRef[:] = image.attrib.get("fileName")
+        imageFileRef.append(image.attrib.get("fileName"))
         _normalizeGlifImage(image, writer)
     if outline is not None:
         if glifVersion == 1:


### PR DESCRIPTION
The former `imageFileRef[:]` notation would change a file name (e.g. `image.png`) to `['i', 'm', 'a', 'g', 'e', '.', 'p', 'n', 'g']`. 
Downstream in `imageFileName = imageFileRef[0] if imageFileRef else None` this was passed on as `i` – and therefore not recognized as an image.
Finally, in `imagesToPurge = availableImages - referencedImages`, the available images were actual image paths, while referenced images were just strings like `a`, `b`, `c` – this means that all images were just flushed.

I’ve tested with my own data and the UFO in #65 – both work.
I also tested using a UFO with multiple images, which also works fine.