### PR TITLE
Do not write empty keys

### DIFF
--- a/src/ufonormalizer/__init__.py
+++ b/src/ufonormalizer/__init__.py
@@ -355,8 +355,10 @@ def normalizeGlyphsDirectory(ufoPath, layerDirectory,
             modTimes[fileName] = subpathGetModTime(ufoPath, layerDirectory, fileName)
     if writeModTimes:
         storeModTimes(layerLib, modTimes)
-    storeImageReferences(layerLib, imageReferences)
-    layerInfo["lib"] = layerLib
+    if imageReferences:
+        storeImageReferences(layerLib, imageReferences)
+    if layerLib:
+        layerInfo["lib"] = layerLib
     subpathWritePlist(layerInfo, ufoPath, layerDirectory, "layerinfo.plist")
     normalizeLayerInfoPlist(ufoPath, layerDirectory)
     referencedImages = set(imageReferences.values())


### PR DESCRIPTION
This adds two if-conditions to check if layer-lib keys are empty.

- in the lib of every `layerinfo.plist`, write the `org.unifiedfontobject.normalizer.imageReferences` dict only if there are images in the UFO
- consequently, only write the lib in `layerinfo.plist` if it does contain anything at all

Fixes #60