### PR TITLE
Support multiple UFOs at once

### DIFF
--- a/tests/test_ufonormalizer.py
+++ b/tests/test_ufonormalizer.py
@@ -1436,6 +1436,13 @@ class UFONormalizerTest(unittest.TestCase):
                 main([existing_not_ufo_file])
             self.assertLogsContain(logs, "Skipping input path that isn't a UFO")
 
+    def test_main_multiple_inputs_and_output(self):
+        stream = StringIO()
+        with self.assertRaisesRegex(SystemExit, '2'):
+            with redirect_stderr(stream):
+                main(['--output', 'foo', 'bar', 'baz'])
+        self.assertIn("can't use -o/--output with multiple input UFOs", stream.getvalue())
+
     def test_main_invalid_float_precision(self):
         stream = StringIO()
         with TemporaryDirectory(suffix=".ufo") as tmp:


### PR DESCRIPTION
Changes the CLI to support taking multiple inputs. Incompatible with `-o/--output`

Happy to adjust implementation/testing as required. If there's any bad formatting let me know, I didn't see a strong standard defined anywhere and my editor's formatter was ready to eviscerate the whole file

I've tried to keep the program acting as similarly as possible - e.g. exiting with code 2 if no valid paths were provided - but also permissive, so the whole program doesn't bomb out if one input path of many is bad

Also, as far as I can see we could mark Python 3.12 as officially supported (I used it while developing/testing these changes), I can update the README & CI if you'd like :)

Finally, please consider making the repository more approachable to new contributors: https://matklad.github.io/2022/10/24/actions-permissions.html