### PR TITLE
Order anchors alphabetically

### DIFF
--- a/src/ufonormalizer/__init__.py
+++ b/src/ufonormalizer/__init__.py
@@ -656,7 +656,7 @@ def normalizeGLIFString(text, glifPath=None, imageFileRef=None):
         else:
             _normalizeGlifOutlineFormat2(outline, writer)
     if glifVersion >= 2:
-        for anchor in anchors:
+        for anchor in sorted(anchors, key=lambda e: e.attrib.get("name", "")):
             _normalizeGlifAnchor(anchor, writer)
     if glifVersion >= 2:
         for guideline in guidelines:

--- a/tests/data/glif/format2.glif
+++ b/tests/data/glif/format2.glif
@@ -24,6 +24,7 @@
 		<component base="a"/>
 	</outline>
 	<anchor name="top" x="74" y="197"/>
+	<anchor name="bottom" x="74" y="0"/>
 	<guideline name="overshoot" y="-12"/>
 	<lib>
 		<dict>

--- a/tests/test_ufonormalizer.py
+++ b/tests/test_ufonormalizer.py
@@ -95,6 +95,7 @@ GLIFFORMAT2 = '''\
         </contour>
         <component base="a"/>
     </outline>
+    <anchor name="bottom" x="74" y="0"/>
     <anchor name="top" x="74" y="197"/>
     <guideline name="overshoot" y="-12"/>
     <lib>


### PR DESCRIPTION
This change orders anchors alphabetically, by name. It also adjusts the unit tests to check this anchor ordering.

I'm not sure if this type of ordering follows the philosophy of `ufoNormalizer`, but in case it does, here is a PR that could be used.

Resolves #98.